### PR TITLE
Swapped out call to eliminate possible crash

### DIFF
--- a/InterviewProject/Views/GIFViewController.swift
+++ b/InterviewProject/Views/GIFViewController.swift
@@ -16,8 +16,8 @@ class GIFViewController: UIViewController {
     @IBOutlet weak var gifImageView: UIImageView!
     @IBOutlet weak var gifQueryTextField: UITextField!
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         setup()
         dismissKeyboardTapGesture()
     }


### PR DESCRIPTION
I noticed that on different machines the app would crash when tapping the button to get the gif. I swapped out viewDidLoad for viewDidAppear and that seemed to do the trick.